### PR TITLE
Fix the commend of getting the name of current branch

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -31,7 +31,7 @@ const utils = {
     return JSON.parse(content)
   },
   async currentBranch (cwd) {
-    const {stdout, stderr} = await execAsync('git name-rev --name-only HEAD', {cwd})
+    const {stdout, stderr} = await execAsync('git symbolic-ref --short HEAD', {cwd})
     return String(stdout).trim()
   },
   async publishedVersion (name) {


### PR DESCRIPTION
@okunishinishi 

`git name-rev` は指定したコミットに対するブランチ名またはタグ名を表示するため、タグ付きコミットではタグ名を表示することになる。

なのでブランチ名を表示するコマンドは [symbolic-ref](https://git-scm.com/docs/git-symbolic-ref) のほうがいいらしいです。

https://qiita.com/sugyan/items/83e060e895fa8ef2038c